### PR TITLE
Add Render cron configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,6 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Focus Reminder Cron (Render)
+A shell script and `render.yaml` are provided under `focus-reminder/` to run a focus reminder every two minutes using Render's Cron Job service. Create a new Cron Job on Render, point it at this repository, and add your `TODOIST_TOKEN`, `PUSHOVER_APP_TOKEN`, and `PUSHOVER_USER_KEY` secrets in the Environment tab.

--- a/focus-reminder/focus-reminder.sh
+++ b/focus-reminder/focus-reminder.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Simple reminder script that sends a message via Pushover
+title="Focus Reminder"
+message="Time to focus on your top task!"
+
+if [ -z "${PUSHOVER_APP_TOKEN:-}" ] || [ -z "${PUSHOVER_USER_KEY:-}" ]; then
+  echo "Pushover environment variables are missing" >&2
+  exit 1
+fi
+
+curl -s \
+  --form-string "token=$PUSHOVER_APP_TOKEN" \
+  --form-string "user=$PUSHOVER_USER_KEY" \
+  --form-string "title=$title" \
+  --form-string "message=$message" \
+  https://api.pushover.net/1/messages.json >/dev/null

--- a/focus-reminder/render.yaml
+++ b/focus-reminder/render.yaml
@@ -1,0 +1,14 @@
+services:
+  - type: cron
+    name: focus-reminder
+    env: docker
+    repo: https://github.com/<yourusername>/focus-reminder
+    schedule: "*/2 * * * *"
+    startCommand: ./focus-reminder.sh
+    envVars:
+      - key: TODOIST_TOKEN
+        sync: false
+      - key: PUSHOVER_APP_TOKEN
+        sync: false
+      - key: PUSHOVER_USER_KEY
+        sync: false


### PR DESCRIPTION
## Summary
- add `focus-reminder` folder with a simple reminder script
- configure Render cron job in `render.yaml`
- document the cron setup in the README

## Testing
- `npm run lint` *(fails to run Next.js because dependencies are missing, but script exits successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684d8b5b93b883329d9fb66588f65dd3