### PR TITLE
Add Pushcut reminder script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,6 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Focus Reminder Cron (Render)
 The script at `focus-reminder/focus-reminder.sh` now fetches your highest priority Todoist task and sends it via Pushover. It requires `jq` to parse the Todoist API response. A `render.yaml` configuration is provided to run the script every two minutes using Render's Cron Job service. Create a new Cron Job on Render, point it at this repository, and add your `TODOIST_TOKEN`, `PUSHOVER_APP_TOKEN`, and `PUSHOVER_USER_KEY` secrets in the Environment tab.
+
+## Pushcut Reminder Cron (Render)
+The script at `pushcut-reminder/pushcut-reminder.sh` sends your highest priority Todoist task to Pushcut so your "Speak Top Task" Shortcut can read it aloud. Like the Pushover version, it requires `jq` and uses the same Todoist query. Configure a Render Cron Job with the provided `render.yaml` and add `TODOIST_TOKEN` and `PUSHCUT_URL` as environment variables.

--- a/pushcut-reminder/pushcut-reminder.sh
+++ b/pushcut-reminder/pushcut-reminder.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch the top Todoist task and send it via Pushcut
+
+if [ -z "${TODOIST_TOKEN:-}" ] || [ -z "${PUSHCUT_URL:-}" ]; then
+  echo "Required environment variables are missing" >&2
+  exit 1
+fi
+
+TASK=$(curl -s \
+  -H "Authorization: Bearer $TODOIST_TOKEN" \
+  "https://api.todoist.com/rest/v2/tasks?filter=priority%204%20|%20priority%203&limit=1" | \
+  jq -r '.[0].content // "No top-priority tasks"')
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"input\":\"$TASK\"}" \
+  "$PUSHCUT_URL" >/dev/null

--- a/pushcut-reminder/render.yaml
+++ b/pushcut-reminder/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: cron
+    name: pushcut-reminder
+    env: docker
+    repo: https://github.com/<yourusername>/pushcut-reminder
+    schedule: "*/2 * * * *"
+    startCommand: ./pushcut-reminder.sh
+    envVars:
+      - key: TODOIST_TOKEN
+        sync: false
+      - key: PUSHCUT_URL
+        sync: false


### PR DESCRIPTION
## Summary
- add new `pushcut-reminder` folder with a script that fetches the highest priority Todoist task and posts it to the Pushcut API
- include Render `render.yaml` example for running the Pushcut script as a cron job
- document the new Pushcut reminder in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d9fae2eac8332968552969da4af8e