### PR TITLE
Add Twilio reminder cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,6 @@ The script at `focus-reminder/focus-reminder.sh` now fetches your highest priori
 
 ## Pushcut Reminder Cron (Render)
 The script at `pushcut-reminder/pushcut-reminder.sh` sends your highest priority Todoist task to Pushcut so your "Speak Top Task" Shortcut can read it aloud. Like the Pushover version, it requires `jq` and uses the same Todoist query. Configure a Render Cron Job with the provided `render.yaml` and add `TODOIST_TOKEN` and `PUSHCUT_URL` as environment variables.
+
+## Twilio Reminder Cron (Render)
+The script at `twilio-reminder/twilio-reminder.sh` sends your highest priority Todoist task via SMS using Twilio. Use the `render.yaml` in that directory to schedule a Render Cron Job. Provide `TODOIST_TOKEN`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`, and `TWILIO_TO_NUMBER` in the Environment tab.

--- a/twilio-reminder/render.yaml
+++ b/twilio-reminder/render.yaml
@@ -1,0 +1,18 @@
+services:
+  - type: cron
+    name: twilio-reminder
+    env: docker
+    repo: https://github.com/<yourusername>/twilio-reminder
+    schedule: "*/2 * * * *"
+    startCommand: ./twilio-reminder.sh
+    envVars:
+      - key: TODOIST_TOKEN
+        sync: false
+      - key: TWILIO_ACCOUNT_SID
+        sync: false
+      - key: TWILIO_AUTH_TOKEN
+        sync: false
+      - key: TWILIO_FROM_NUMBER
+        sync: false
+      - key: TWILIO_TO_NUMBER
+        sync: false

--- a/twilio-reminder/twilio-reminder.sh
+++ b/twilio-reminder/twilio-reminder.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch the top Todoist task and send it via Twilio SMS
+
+if [ -z "${TODOIST_TOKEN:-}" ] || [ -z "${TWILIO_ACCOUNT_SID:-}" ] || [ -z "${TWILIO_AUTH_TOKEN:-}" ] || [ -z "${TWILIO_FROM_NUMBER:-}" ] || [ -z "${TWILIO_TO_NUMBER:-}" ]; then
+  echo "Required environment variables are missing" >&2
+  exit 1
+fi
+
+TASK=$(curl -s \
+  -H "Authorization: Bearer $TODOIST_TOKEN" \
+  "https://api.todoist.com/rest/v2/tasks?filter=priority%204%20|%20priority%203&limit=1" | \
+  jq -r '.[0].content // "No top-priority tasks"')
+
+curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages.json" \
+  --data-urlencode "From=$TWILIO_FROM_NUMBER" \
+  --data-urlencode "To=$TWILIO_TO_NUMBER" \
+  --data-urlencode "Body=$TASK" \
+  -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" >/dev/null


### PR DESCRIPTION
## Summary
- add Twilio reminder cron job script
- add Render config for the new cron job
- document the Twilio Reminder Cron setup in README

## Testing
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e39f920ec83328b33882227bff0d3