### PR TITLE
Fix Pushover script

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
 ## Focus Reminder Cron (Render)
-The script at `focus-reminder/focus-reminder.sh` now fetches your highest priority Todoist task and sends it via Pushover with the task shown as the notification title. It requires `jq` to parse the Todoist API response. A `render.yaml` configuration is provided to run the script every two minutes using Render's Cron Job service. Create a new Cron Job on Render, point it at this repository, and add your `TODOIST_TOKEN`, `PUSHOVER_APP_TOKEN`, and `PUSHOVER_USER_KEY` secrets in the Environment tab.
+The script at `focus-reminder/focus-reminder.sh` fetches your highest priority Todoist task and sends it via Pushover. The task text is used for both the notification title and message so Pushover accepts the request. It requires `jq` to parse the Todoist API response. A `render.yaml` configuration is provided to run the script every two minutes using Render's Cron Job service. Create a new Cron Job on Render, point it at this repository, and add your `TODOIST_TOKEN`, `PUSHOVER_APP_TOKEN`, and `PUSHOVER_USER_KEY` secrets in the Environment tab.
 
 ## Pushcut Reminder Cron (Render)
 The script at `pushcut-reminder/pushcut-reminder.sh` sends your highest priority Todoist task to Pushcut so your "Speak Top Task" Shortcut can read it aloud. Like the Pushover version, it requires `jq` and uses the same Todoist query. Configure a Render Cron Job with the provided `render.yaml` and add `TODOIST_TOKEN` and `PUSHCUT_URL` as environment variables.

--- a/focus-reminder/focus-reminder.sh
+++ b/focus-reminder/focus-reminder.sh
@@ -8,14 +8,14 @@ if [ -z "${TODOIST_TOKEN:-}" ] || [ -z "${PUSHOVER_APP_TOKEN:-}" ] || [ -z "${PU
   exit 1
 fi
 
-TASK=$(curl -s \
+TASK=$(curl -sf \
   -H "Authorization: Bearer $TODOIST_TOKEN" \
   "https://api.todoist.com/rest/v2/tasks?filter=priority%204%20|%20priority%203&limit=1" | \
   jq -r '.[0].content // "No top-priority tasks"')
 
-curl -s \
+curl -sf \
   -F "token=$PUSHOVER_APP_TOKEN" \
   -F "user=$PUSHOVER_USER_KEY" \
   -F "title=$TASK" \
-  -F "message= " \
+  -F "message=$TASK" \
   https://api.pushover.net/1/messages.json >/dev/null


### PR DESCRIPTION
## Summary
- send the Todoist task as both title and message in focus reminder
- note message behaviour in README
- fail fast on HTTP errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e5d3405b883329efb03210eb8cc82